### PR TITLE
Update distributed-iam-policy.tf for latest version (v2.13.4)

### DIFF
--- a/src/distributed-iam-policy.tf
+++ b/src/distributed-iam-policy.tf
@@ -14,8 +14,8 @@
 
 locals {
   # To update, just replace everything between the two "EOT"s with the contents of the downloaded JSON file.
-  # Below is the policy as of version 2.6.0, downloaded from
-  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.6.0/docs/install/iam_policy.json
+  # Below is the policy as of version 2.13.4, downloaded from
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.13.4/docs/install/iam_policy.json
   # This policy is for the `aws` partition. Override overridable_distributed_iam_policy for other partitions.
   overridable_distributed_iam_policy = <<EOT
 {
@@ -49,6 +49,9 @@ locals {
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",
@@ -59,7 +62,9 @@ locals {
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetHealth",
                 "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTrustStores"
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
             ],
             "Resource": "*"
         },
@@ -208,7 +213,10 @@ locals {
                 "elasticloadbalancing:DeleteLoadBalancer",
                 "elasticloadbalancing:ModifyTargetGroup",
                 "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup"
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
             ],
             "Resource": "*",
             "Condition": {
@@ -254,7 +262,8 @@ locals {
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:AddListenerCertificates",
                 "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule"
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
Update policy to be able to use latest versions of the `aws-load-balancer-controller` component

## what
Update manually policy to last version.
Should not be an issue since it only add Actions to the policy

## why
When using the latest version of aws-load-balancer-controller, the LB creation fails. Error message indicate missing `elasticloadbalancing:DescribeListenerAttributes` for the associated role

## references
Please, refer to the documentation in the file which explains the update process


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded AWS compatibility by granting additional EC2 permissions (e.g., security groups for VPCs, IPAM pools, route tables).
  - Enhanced Elastic Load Balancing management with listener attributes, capacity reservations, and IP pool modifications.
  - Improved WAF operations by allowing rule priority updates.
- Chores
  - Updated in-policy reference to IAM policy version 2.13.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->