### PR TITLE
fix: Removed Default Tags

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -38,7 +38,9 @@ module "alb_controller" {
     }),
     # alb-controller-specific values
     yamlencode({
-      region                     = var.region
+      aws = {
+        region = var.region
+      }
       vpcId                      = module.vpc.outputs.vpc_id
       clusterName                = module.eks.outputs.eks_cluster_id
       createIngressClassResource = var.default_ingress_enabled
@@ -59,7 +61,6 @@ module "alb_controller" {
       ingressClassConfig = {
         default = var.default_ingress_enabled
       }
-      defaultTags = module.this.tags
     }),
     # additional values
     yamlencode(var.chart_values)

--- a/src/main.tf
+++ b/src/main.tf
@@ -38,9 +38,7 @@ module "alb_controller" {
     }),
     # alb-controller-specific values
     yamlencode({
-      aws = {
-        region = var.region
-      }
+      region                     = var.region
       vpcId                      = module.vpc.outputs.vpc_id
       clusterName                = module.eks.outputs.eks_cluster_id
       createIngressClassResource = var.default_ingress_enabled


### PR DESCRIPTION
## what

Removed passing `module.this.tags` to `defaultTags` to the alb controller chart

## why

Services like `echo-server` were using `k8s-common` ALB instead of the provisioned `alb-controller-ingress-group` ALB, despite having `ingress_type: "alb"` configured.

The root cause was tag conflicts: the ALB Controller's `defaultTags` (from `module.this.tags`) applied `Name: acme-plat-euc1-dev`, while the ALB controller ingress group applied Name: `acme-plat-euc1-dev-alb-controller-ingress-group`. These conflicting `Name` tags prevented the AWS Load Balancer Controller from reconciling ingresses into the target group.

Ingresses should manage their own tags rather than inheriting the tags from this component.

## references
- https://github.com/cloudposse-terraform-components/aws-eks-alb-controller-ingress-group/pull/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed automatic default tags from the ALB controller values; tagging should now be managed externally.
* **Notes**
  * No public interfaces changed; no action required beyond updating your tagging strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->