### PR TITLE
fix: handle empty string in kube_exec_auth_role_arn

### DIFF
--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -133,8 +133,9 @@ locals {
     "--profile", var.kube_exec_auth_aws_profile
   ] : []
 
+  kube_exec_auth_role_arn = var.kube_exec_auth_role_arn != "" ? var.kube_exec_auth_role_arn : try(module.iam_roles.terraform_role_arn, "")
   exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
-    "--role-arn", coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+    "--role-arn", local.kube_exec_auth_role_arn
   ] : []
 
   # Provide dummy configuration for the case where the EKS cluster is not available.


### PR DESCRIPTION
## What
Fix handling of empty string for `kube_exec_auth_role_arn` variable.

## Why
`coalesce()` only skips null values, not empty strings. When `kube_exec_auth_role_arn` is set to an empty string and `kube_exec_auth_role_arn_enabled` is false, the evaluation still fails.

The fix:
- Checks if `var.kube_exec_auth_role_arn` is non-empty and uses it if so
- Otherwise, tries `module.iam_roles.terraform_role_arn` (safely returns "" if missing)
- If `kube_exec_auth_role_arn_enabled: false`, the role ARN won't be used, and the evaluation no longer fails

## References
- Context from customer implementations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal infrastructure code optimization. No changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->