### PR TITLE
feat: gate ALB controller on EKS Auto Mode

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,12 @@
+locals {
+  enabled = module.this.enabled && !var.eks_auto_mode_enabled
+}
+
 module "alb_controller" {
   source  = "cloudposse/helm-release/aws"
   version = "0.10.1"
+
+  enabled = local.enabled
 
   chart           = var.chart
   repository      = var.chart_repository

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -3,6 +3,13 @@ variable "region" {
   type        = string
 }
 
+variable "eks_auto_mode_enabled" {
+  type        = bool
+  description = "Set to true if the EKS cluster has Auto Mode networking enabled. When true, this component is disabled because Auto Mode includes built-in elastic load balancing support, making a self-managed ALB controller unnecessary."
+  default     = false
+  nullable    = false
+}
+
 variable "chart_description" {
   type        = string
   description = "Set release description attribute (visible in the history)."


### PR DESCRIPTION
## Summary
- Add `eks_auto_mode_enabled` variable (bool, default `false`)
- Gate all resources via `local.enabled = module.this.enabled && !var.eks_auto_mode_enabled`
- When Auto Mode networking is enabled, the built-in elastic load balancing replaces the self-managed ALB controller

## Test plan
- [ ] `terraform plan` with `eks_auto_mode_enabled = false` shows no changes (backward compat)
- [ ] `terraform plan` with `eks_auto_mode_enabled = true` shows all resources destroyed/not created
- [ ] Verify helm release, IAM role, and IngressClass are all gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to enable or disable EKS auto mode
  * ALB controller deployment is now conditional, only applied when EKS auto mode is disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->